### PR TITLE
Upgrade axios to 1.12.0 to fix DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9107,13 +9107,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "@types/react-transition-group": "^4.4.12",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "axios": "1.12.0"
   }
 }


### PR DESCRIPTION
# Upgrade axios to 1.12.0 to fix DoS vulnerability

## Summary
Upgrades axios from 1.9.0 to 1.12.0 using npm overrides to fix a **high severity DoS vulnerability** (GHSA-4hjh-wcwx-xvwj). The vulnerability allows attackers to cause denial of service through lack of data size checking in axios versions < 1.12.0.

**Changes:**
- Added `"overrides": { "axios": "1.12.0" }` to package.json
- Updated package-lock.json to reflect axios@1.12.0 across all transitive dependencies
- Fixes vulnerability in packages: @dynamic-labs-wallet/core, @stellar/stellar-sdk

**Impact:** Reduces total security vulnerabilities from 18 to 15.

## Review & Testing Checklist for Human
⚠️ **HIGH RISK** - This overrides a transitive dependency used by wallet and blockchain packages

- [ ] **Test complete onramp flow end-to-end** - Create order, complete KYC, process payment, verify delivery
- [ ] **Test wallet operations** - Verify @stellar/stellar-sdk and @dynamic-labs functionality still works 
- [ ] **Check browser console for new errors** - Monitor network requests and console during testing
- [ ] **Verify security fix** - Run `npm audit` to confirm axios vulnerability is resolved
- [ ] **Test in different browsers** - Ensure compatibility across Chrome, Firefox, Safari

### Notes
- No breaking changes documented between axios 1.9.0 → 1.12.0 (checked release notes)
- Build and dev server tested successfully, but **actual onramp functionality not tested**
- This PR uses npm overrides which bypasses the exact version pin from @dynamic-labs-wallet/core

**Link to Devin run:** https://app.devin.ai/sessions/85ff1844d19b486bab86d1eeffb557a3  
**Requested by:** @soinclined